### PR TITLE
Fix tie chaining: multiple consecutive ties now extend note correctly

### DIFF
--- a/sequencer/sequencer_metro.py
+++ b/sequencer/sequencer_metro.py
@@ -291,7 +291,7 @@ class SequencerMetro(object):
 
             instrument = self.app.instruments[self.name]
 
-            if self.gate[self.step_index] != "Off" and gate_track_active:
+            if self.gate[self.step_index] == True and gate_track_active:
                 gate = 1
                 pitch = self.pitch[self.step_index] if self.pitch[self.step_index] is not None else 0
                 octave = self.octave[self.step_index] * 12 if self.octave[self.step_index] is not None else 0
@@ -301,22 +301,29 @@ class SequencerMetro(object):
                 gate = None
 
                 gate_len = params.gate_len
-                
+
                 column = int(self.step_index / 8)
                 mutes_idx = column*8+1
-                
-                
+
+
                 prob = 1
-                
+
                 # checking columns for the True statement
                 for x in range(7):
                     if self.mutes_skips[mutes_idx + x] == True:
                         prob = x
-                        
-                next_step_index = self.next_step_index
-                
-                if self.gate[next_step_index] == "Tie":
-                    gate = 0.3
+
+                # Count consecutive ties after this step to determine gate length.
+                # Each tie extends the note by one step; the gate value of 0.3 per
+                # step was chosen to overlap cleanly into the next tick.
+                tie_count = 0
+                check_idx = self.next_step_index
+                while self.gate[check_idx] == "Tie" and tie_count < 64:
+                    tie_count += 1
+                    check_idx = (check_idx + 1) % 64
+
+                if tie_count > 0:
+                    gate = (1 + tie_count) * 0.3
                 else:
                     gate = 0.25 * gate_len
             


### PR DESCRIPTION
## Summary

Two bugs in the gate evaluation tick in `sequencer/sequencer_metro.py`:

**Bug 1 — Tie steps fired new note-ons**

The guard condition `gate[step] != "Off"` also matches `"Tie"`, so every tie step in a chain would schedule an independent `note-on`. Changed to `gate[step] == True` so only genuine note steps trigger playback.

**Bug 2 — Gate look-ahead only extended by one step**

The previous code checked only `self.next_step_index` to decide if a tie was coming, and always set `gate = 0.3` regardless of how many ties followed. Replaced with a forward walk that counts all consecutive `"Tie"` values and sets:

```
gate = (1 + tie_count) * 0.3
```

So a note followed by two ties gets `gate = 0.9`, sustaining across the full tied region.

## Behaviour before/after

| Pattern | Before | After |
|---|---|---|
| `note, tie` | ✅ one long note | ✅ one long note |
| `note, tie, tie` | ❌ note + tie + new note | ✅ one longer note |
| `tie, tie` | ❌ two normal notes | ✅ silence |

## Test plan

- [ ] `[note, tie]` — single long note as before
- [ ] `[note, tie, tie]` — one longer note, no restart
- [ ] `[note, tie, tie, tie]` — even longer note
- [ ] `[tie, tie]` — silence (no preceding note to extend)
- [ ] All 194 unit tests pass (`python -m pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)