### PR TITLE
Fix OSCControlSwitch display flickering and missing contextual display when pad held

### DIFF
--- a/modes/osc_device.py
+++ b/modes/osc_device.py
@@ -164,7 +164,7 @@ class OSCDevice(PyshaMode):
     def draw(self, ctx):
         visible_controls = self.get_visible_controls()
         instrument_name = self.app.metro_sequencer_mode.get_current_instrument_short_name_helper()
-        
+
         seq = self.app.metro_sequencer_mode.instrument_sequencers[instrument_name]
         draw_lock = False
         step = None
@@ -173,8 +173,29 @@ class OSCDevice(PyshaMode):
             draw_lock = True
             step = self.app.steps_held[0]
 
-        
+        # When a pad is held, temporarily override each OSCControlSwitch's value
+        # to the held pad's lock value so that self.pages shows the locked group's
+        # controls instead of the current (playhead-driven) group.
+        # The override is restored immediately after pages is computed so it never
+        # persists between frames and cannot cause flicker.
+        switch_saved_values = {}
+        if step is not None:
+            pg, pg_offset = 0, 0
+            for ctrl in self.controls:
+                if pg_offset + ctrl.size > 8:
+                    pg += 1
+                    pg_offset = 0
+                if pg == self.page and isinstance(ctrl, OSCControlSwitch):
+                    lv = seq.get_lock_state(step, pg_offset + pg * 8)
+                    if lv is not None:
+                        switch_saved_values[ctrl] = ctrl.value
+                        ctrl.value = lv
+                pg_offset += ctrl.size
+
         all_controls = self.pages
+
+        for ctrl, saved in switch_saved_values.items():
+            ctrl.value = saved
         offset = 0
         
         # TODO: Those are broken, subpage does not draw correctly

--- a/osc_controls.py
+++ b/osc_controls.py
@@ -620,14 +620,9 @@ class OSCControlSwitch(object):
         prev_label = ""
         
         idx = int(self.knob_value)
-        self.value = self.knob_value
         if draw_lock != False:
-            # TODO: do we need to set the value somewhere here to update the visual feedback?
-            # font_color = definitions.RED
             font_color = self.get_color_func()
             if lock_value is not None:
-                self.lock_value = lock_value
-                self.value = lock_value
                 idx = int(lock_value)
             else:
                 idx = int(0.0)


### PR DESCRIPTION
## Summary

- `OSCControlSwitch.draw()` was mutating `self.value` as a side effect, which the `pages` property (a dynamic property that calls `get_active_group()` → reads `self.value`) relied on to show the locked group's controls when a pad was held.
- This caused flicker during playback: `reset_group()` fired on every note tick, resetting `self.value` back to `knob_value`, fighting with the draw mutation on every frame.
- An initial fix removed the draw mutation entirely — killing the flicker but also breaking the contextual display (held pad no longer showed the locked group).

The correct fix is in `OSCDevice.draw()`: before computing `self.pages`, walk `self.controls` to find each `OSCControlSwitch`, temporarily set `ctrl.value` to the held pad's lock value, compute `pages` (which reads that value to pick the active group), then **immediately restore `ctrl.value`**. The override never persists between frames so `reset_group()` has nothing to fight.

`OSCControlSwitch.draw()` is also cleaned up to be side-effect free (no more `self.value` or `self.lock_value` mutations during rendering).

## Test plan

- [ ] Hold a pad that has an OSCControlSwitch lock set — the display should show the locked group's label and controls
- [ ] Start the sequencer playing while holding that pad — display should stay stable on the locked group (no flicker)
- [ ] Release the pad — display should return to the real current group
- [ ] `python -m pytest` passes (194 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)