### PR TITLE
Fix param lock encoder reading wrong controls for OSCControlSwitch group layout

### DIFF
--- a/modes/metro_sequencer_mode.py
+++ b/modes/metro_sequencer_mode.py
@@ -1109,14 +1109,17 @@ class MetroSequencerMode(MelodicMode):
                     idx = int(self.steps_held[0]%8)
                     value = None
                     page_offset = int(device.page) * 8
-                    
+                    visible_controls = device.get_visible_controls()
+
+                    if encoder_idx >= len(visible_controls):
+                        return
+
+                    control = visible_controls[encoder_idx]
+
                     if seq.get_lock_state(idx, encoder_idx + page_offset) == None:
-                        value = device.controls[
-                            encoder_idx
-                        ].value
+                        value = control.value
                     else:
-                        # calmping to min/max values, scaling
-                        control = device.controls[encoder_idx + page_offset]
+                        # clamping to min/max values, scaling
                         lock_value = seq.get_lock_state(idx, encoder_idx + page_offset)
 
                         if hasattr(control, "groups"):


### PR DESCRIPTION
## Summary

- When holding a pad and rotating encoders to set param locks, `metro_sequencer_mode` was looking up the control via `device.controls[encoder_idx]` — the flat top-level control list.
- For devices like Twist, an `OSCControlSwitch` expands its active group's controls **inline** on the page (via the dynamic `pages` property). The page visible layout and `device.controls` have different indices for these group controls.
- Encoders 5 & 6 (group controls 2 & 3) hit `device.controls[4]`/`[5]` = `OSCSpacerAddress` instances with `value = 0.0`, so locks were always stored as 0.
- Encoders 3 & 4 "worked" by coincidence: `device.controls[2]`/`[3]` are LPG Resp/Decay (real range controls) — wrong controls, but at least non-zero.

**Fix:** Use `device.get_visible_controls()[encoder_idx]` (the page layout with group controls expanded) for the control lookup in both the initial-value read and the clamp calculation. Also add a bounds check so encoders past the page width return cleanly.

For Twist page 0 the visible layout is:
```
[Pitch, Engine-switch, group_c0, group_c1, group_c2, group_c3, LPG Resp, LPG Decay]
```
Encoder positions now map to the correct controls.

## Test plan

- [ ] Select Twist oscillator, hold a step
- [ ] Rotate encoders 1–8: all should produce valid lock values matching the displayed parameter
- [ ] Encoders 5 & 6 (group controls 2 & 3) should no longer lock to zero
- [ ] Lock values should play back correctly when the sequencer runs
- [ ] `python -m pytest` passes (194 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)